### PR TITLE
add option to add null terminator to string values and tags

### DIFF
--- a/include/xml/call/xml.h
+++ b/include/xml/call/xml.h
@@ -33,16 +33,13 @@ extern "C" {
  *  4. free XML document with xml_free()
  *  5. free `contents`
  *
- * @param[in] contents          XML string
- * @param[in] reverse           store members, array items as reverse order
- * @param[in] separatePrefixes  separate prefixes and store them in xml->prefix
+ * @param[in] contents XML string
+ * @param[in] options  options use XML_DEFAULTS or XML_NONE for default
  * @return xml document which contains xml object as root object
  */
 XML_EXPORT
 xml_doc_t*
-xmlc_parse(const char * __restrict contents,
-           bool                    reverse,
-           bool                    separatePrefixes);
+xmlc_parse(const char * __restrict contents, xml_options_t options);
 
 /*!
  * @brief frees xml document and its allocated memory

--- a/include/xml/common.h
+++ b/include/xml/common.h
@@ -64,9 +64,10 @@ typedef struct xml_t {
   const char        *tag;
   void              *val;
   uint32_t           valsize;
-  uint32_t           tagsize;
-  uint32_t           prefixsize;
-  xml_type_t         type;
+  uint16_t           tagsize;
+  uint16_t           prefixsize;
+  xml_type_t         type:16;
+  bool               readonly:1;
 } xml_t;
 
 typedef struct xml_doc_t {

--- a/include/xml/impl/impl_parse.h
+++ b/include/xml/impl/impl_parse.h
@@ -12,12 +12,12 @@
 #include "impl_mem.h"
 
 typedef enum xml_position {
-  unknown  = 0,
-  begintag = 1,
-  endtag,
-  beginel,
-  endel,
-  beginattr
+  unknown   = 0,
+  begintag  = 1,
+  endtag    = 2,
+  beginel   = 3,
+  endel     = 4,
+  beginattr = 5
 } xml_position;
 
 XML_INLINE

--- a/include/xml/print.h
+++ b/include/xml/print.h
@@ -99,7 +99,7 @@ xml_print_ex(FILE  * __restrict ostream,
         break;
       }
       case XML_STRING:
-        fprintf(ostream, "%.*s", xml->valsize, xmls(xml));
+        fprintf(ostream, "%.*s", xml->valsize, xml->val);
         break;
       default:
         break;

--- a/include/xml/util.h
+++ b/include/xml/util.h
@@ -47,8 +47,8 @@ xml_xml(const xml_t * __restrict object) {
  * @return string node
  */
 XML_INLINE
-xml_t*
-xmls_next(xml_t * __restrict obj) {
+const xml_t*
+xmls_next(const xml_t * __restrict obj) {
   do {
     if (!obj || obj->type == XML_STRING)
       return obj;
@@ -68,8 +68,8 @@ xmls_next(xml_t * __restrict obj) {
  * @return non-NULL terminated string value (pointer only)
  */
 XML_INLINE
-xml_t*
-xmls(xml_t * __restrict obj) {
+const xml_t*
+xmls(const xml_t * __restrict obj) {
   if (!obj && !(obj = obj->val))
     return NULL;
   return xmls_next(obj);
@@ -85,11 +85,12 @@ xmls(xml_t * __restrict obj) {
 XML_INLINE
 int32_t
 xml_i32(const xml_t * __restrict obj, int32_t defaultValue) {
-  const char *v;
+  const xml_t *v;
+
   if (!(v = xmls(obj)))
     return defaultValue;
 
-  return (int32_t)strtol(v, NULL, 10);
+  return (int32_t)strtol(v->val, NULL, 10);
 }
 
 /*!
@@ -102,11 +103,12 @@ xml_i32(const xml_t * __restrict obj, int32_t defaultValue) {
 XML_INLINE
 uint32_t
 xml_u32(const xml_t * __restrict obj, uint32_t defaultValue) {
-  const char *v;
+  const xml_t *v;
+
   if (!(v = xmls(obj)))
     return defaultValue;
 
-  return (uint32_t)strtoul(v, NULL, 10);
+  return (uint32_t)strtoul(v->val, NULL, 10);
 }
 
 /*!
@@ -119,11 +121,12 @@ xml_u32(const xml_t * __restrict obj, uint32_t defaultValue) {
 XML_INLINE
 int64_t
 xml_i64(const xml_t * __restrict obj, int64_t defaultValue) {
-  const char *v;
+  const xml_t *v;
+
   if (!(v = xmls(obj)))
     return defaultValue;
 
-  return strtoll(v, NULL, 10);
+  return strtoll(v->val, NULL, 10);
 }
 
 /*!
@@ -136,11 +139,12 @@ xml_i64(const xml_t * __restrict obj, int64_t defaultValue) {
 XML_INLINE
 uint64_t
 xml_u64(const xml_t * __restrict obj, uint64_t defaultValue) {
-  const char *v;
+  const xml_t *v;
+
   if (!(v = xmls(obj)))
     return defaultValue;
 
-  return strtoull(v, NULL, 10);
+  return strtoull(v->val, NULL, 10);
 }
 
 /*!
@@ -153,11 +157,12 @@ xml_u64(const xml_t * __restrict obj, uint64_t defaultValue) {
 XML_INLINE
 float
 xml_float(const xml_t * __restrict obj, float defaultValue) {
-  const char *v;
+  const xml_t *v;
+
   if (!(v = xmls(obj)))
     return defaultValue;
 
-  return strtof(v, NULL);
+  return strtof(v->val, NULL);
 }
 
 /*!
@@ -170,11 +175,12 @@ xml_float(const xml_t * __restrict obj, float defaultValue) {
 XML_INLINE
 double
 xml_double(const xml_t * __restrict obj, double defaultValue) {
-  const char *v;
+  const xml_t *v;
+
   if (!(v = xmls(obj)))
     return defaultValue;
 
-  return strtod(v, NULL);
+  return strtod(v->val, NULL);
 }
 
 /*!
@@ -187,13 +193,13 @@ xml_double(const xml_t * __restrict obj, double defaultValue) {
 XML_INLINE
 int
 xml_bool(const xml_t * __restrict obj, int defaultValue) {
-  const char *v;
-  char        first;
+  const xml_t *v;
+  char         first;
 
   if (!(v = xmls(obj)))
     return defaultValue;
 
-  first = v[0];
+  first = *(char *)v->val;
 
   return first == 't' || first == '1';
 }

--- a/include/xml/xml.h
+++ b/include/xml/xml.h
@@ -12,6 +12,41 @@
 #include "util.h"
 #include "attrib.h"
 
+typedef enum xml_options_t {
+  XML_NONE     = 0,      /* use the default options (XML_DEFAULTS)           */
+  XML_REVERSE  = 1 << 0, /* store members, array items as reverse order      */
+  XML_PREFIXES = 1 << 1, /* separate prefixes and store them in xml->prefix  */
+
+  /*
+   * Don't touch to the content even temporarily, just parse it by creating 
+   * tokens. You cannot use utilities in xml library to convert string to a 
+   * number (strtol, strtof) because null terminator cannot be added. 
+   * But you can duplicate string to another place or bring your own 
+   * string-to-number converter. Since this library wants to be lightweight, 
+   * it won't add this functionality. In the uture things may be changed.
+   */ 
+  XML_READONLY = 1 << 4,
+
+  /* --------------------- DEFAULT OPTIONS ------------------------------------
+   *
+   * Option 1: NULL Terminator for Strings
+   * --------------------------------------------------------------------------
+   * Add null terminator for string values and attributes. You can also use
+   * valsize to get string byte length. All string functions shall work for
+   * xml->val member.
+   *
+   * NOTE: prefixes are not null terminated for now.
+   *
+   * This is disabled in READONLY mode.
+   *
+   * Option 2: separate prefixes from tag name
+   * --------------------------------------------------------------------------
+   * separate prefixes and store them in xml->prefix
+   *
+   */
+  XML_DEFAULTS = XML_PREFIXES
+} xml_options_t;
+
 /*!
  * @brief parse xml string
  *
@@ -31,16 +66,14 @@
  *  4. free XML document with xml_free()
  *  5. free `contents`
  *
- * @param[in] contents          XML string
- * @param[in] reverse           store members, array items as reverse order
- * @param[in] separatePrefixes  separate prefixes and store them in xml->prefix
+ * @param[in] contents XML string
+ * @param[in] options  options use XML_DEFAULTS or XML_NONE for default
+ *
  * @return xml document which contains xml object as root object
  */
 XML_INLINE
 xml_doc_t*
-xml_parse(const char * __restrict contents,
-          bool                    reverse,
-          bool                    separatePrefixes);
+xml_parse(const char * __restrict contents, xml_options_t options);
 
 /*!
  * @brief frees xml document and its allocated memory

--- a/include/xml/xml.h
+++ b/include/xml/xml.h
@@ -25,7 +25,7 @@ typedef enum xml_options_t {
    * string-to-number converter. Since this library wants to be lightweight, 
    * it won't add this functionality. In the uture things may be changed.
    */ 
-  XML_READONLY = 1 << 4,
+  XML_READONLY = 1 << 2,
 
   /* --------------------- DEFAULT OPTIONS ------------------------------------
    *

--- a/src/xml.c
+++ b/src/xml.c
@@ -10,32 +10,35 @@
 static
 xml_doc_t*
 xmlc__parse_reverse(const char * __restrict contents) {
-  return xml_parse(contents, true, true);
+  return xml_parse(contents, XML_REVERSE | XML_PREFIXES);
 }
 
 static
 xml_doc_t*
 xmlc__parse_reverse_nopref(const char * __restrict contents) {
-  return xml_parse(contents, true, false);
+  return xml_parse(contents, XML_REVERSE);
 }
 
 static
 xml_doc_t*
 xmlc__parse_normal(const char * __restrict contents) {
-  return xml_parse(contents, false, true);
+  return xml_parse(contents, XML_PREFIXES);
 }
 
 static
 xml_doc_t*
 xmlc__parse_normal_nopref(const char * __restrict contents) {
-  return xml_parse(contents, false, false);
+  return xml_parse(contents, XML_DEFAULTS);
 }
 
 XML_EXPORT
 xml_doc_t*
-xmlc_parse(const char * __restrict contents,
-            bool                    reverse,
-            bool                    separatePrefixes) {
+xmlc_parse(const char * __restrict contents, xml_options_t options) {
+  bool reverse, separatePrefixes;
+
+  reverse          = options & XML_REVERSE;
+  separatePrefixes = options & XML_PREFIXES;
+
   if (!reverse) {
     if (separatePrefixes)
       return xmlc__parse_normal(contents);


### PR DESCRIPTION
* use `XML_READONLY` to prevent to add null terminator 
* now parse function accepts `xml_options_t` which allows more options for later